### PR TITLE
Tidy up error handling in SYNOPSIS.

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -46,8 +46,8 @@ Version 0.09
  };
  if ( $@ )
  {
-   die $@ if ref $@ ne "Protocol::ACME::Exception";
-   print "Error occured: Status: $@->{status},
+   die if !UNIVERSAL::isa($@, 'Protocol::ACME::Exception');
+   die "Error occured: Status: $@->{status},
                          Detail: $@->{detail},
                          Type: $@->{type}\n";
  }

--- a/lib/Protocol/ACME.pm
+++ b/lib/Protocol/ACME.pm
@@ -56,8 +56,8 @@ Version 0.09
  };
  if ( $@ )
  {
-   die $@ if ref $@ ne "Protocol::ACME::Exception";
-   print "Error occured: Status: $@->{status},
+   die if !UNIVERSAL::isa($@, 'Protocol::ACME::Exception');
+   die "Error occured: Status: $@->{status},
                          Detail: $@->{detail},
                          Type: $@->{type}\n";
  }


### PR DESCRIPTION
- use raw die() to get Perl’s PROPAGATE
- exit nonzero to indicate error
