### PR TITLE
Add missing module to Makefile.PL, clean debug, add use(), fix version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,8 +14,9 @@ WriteMakefile(
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => 0,
     },
-    BUILD_REQUIRES => {
+    TEST_REQUIRES => {
         'Test::More' => 0,
+        'Test::Exception' => 0,
     },
     META_MERGE => {
         'meta-spec' => { version => 2 },
@@ -37,7 +38,7 @@ WriteMakefile(
           'Crypt::RSA::Parse' => '0.02',
           'Crypt::OpenSSL::Bignum' => '0.06',
           'JSON' => '2.90',
-          'Digest::SHA' => '5.9.5',
+          'Digest::SHA' => '5.95',
           'HTTP::Tiny' => '0.054',
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/lib/Protocol/ACME.pm
+++ b/lib/Protocol/ACME.pm
@@ -4,7 +4,6 @@ use 5.007003;
 use strict;
 use warnings;
 
-use Data::Dumper;
 
 our $VERSION = '0.11';
 

--- a/lib/Protocol/ACME/Exception.pm
+++ b/lib/Protocol/ACME/Exception.pm
@@ -3,8 +3,6 @@ package Protocol::ACME::Exception;
 use strict;
 use warnings;
 
-use Data::Dumper;
-
 our $VERSION = '0.11';
 
 # very simple stringification ... make this
@@ -13,7 +11,9 @@ use overload ('""' => \&stringify);
 sub stringify
 {
     my $self = shift;
-    return ref($self).' error: '.Dumper $self;
+
+    require Data::Dumper;
+    return ref($self).' error: '.Data::Dumper::Dumper($self);
 }
 
 sub new

--- a/lib/Protocol/ACME/Key.pm
+++ b/lib/Protocol/ACME/Key.pm
@@ -8,6 +8,7 @@ use warnings;
 our $VERSION = '0.11';
 
 use Crypt::RSA::Parse;
+use Math::BigInt ();
 
 use Protocol::ACME::Utils;
 


### PR DESCRIPTION
This fixes a few small issues that I’ve noticed in this module, having recently come back to trying to implement Let’s Encrypt in our project.
