### PR TITLE
Refactored logger and lowered dependencies.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,18 +29,20 @@ WriteMakefile(
          },
     },
     PREREQ_PM => {
-          'Log::Any::Adapter::Base' => '1.032',
-          'Log::Any' => '1.032',
-          'Log::Any::Adapter' => '1.032',
-          'Log::Any::Adapter::Util' => '1.032',
+                  # here the prerequisites are aligned with Debian
+                  # stable, if they exists, otherwise to stretch (and
+                  # they need backporting: libcrypt-rsa-parse-perl and
+                  # libcrypt-format-perl
+          'Log::Any' => '0.15',
+          'Log::Any::Adapter' => '0.11',
           'Crypt::Format' => '0.04',
           'Crypt::OpenSSL::RSA' => '0.28',
           'Crypt::RSA::Parse' => '0.02',
-          'Crypt::OpenSSL::Bignum' => '0.06',
-          'JSON' => '2.90',
-          'Digest::SHA' => '5.95',
-          'HTTP::Tiny' => '0.054',
-          'Test::Exception' => '0.43',
+          'Crypt::OpenSSL::Bignum' => '0.04',
+          'JSON' => '2.61',
+          'Digest::SHA' => '5.88',
+          'HTTP::Tiny' => '0.050',
+          'Test::Exception' => '0.35',
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Protocol-ACME-*' },

--- a/lib/Protocol/ACME.pm
+++ b/lib/Protocol/ACME.pm
@@ -366,8 +366,9 @@ sub _init
 
   $self->{log} = $args->{'logger'} || do
   {
-    require Protocol::ACME::Logger;
-    Protocol::ACME::Logger->new($self->{loglevel});
+      require Log::Any::Adapter;
+      Log::Any::Adapter->set('+Protocol::ACME::Logger', log_level => $self->{loglevel});
+      Log::Any->get_logger;
   };
 
   if ( exists $args->{account_key} )

--- a/lib/Protocol/ACME/Logger.pm
+++ b/lib/Protocol/ACME/Logger.pm
@@ -3,81 +3,53 @@ package Protocol::ACME::Logger;
 use strict;
 use warnings;
 
-our $VERSION = '0.12';
-
-use Log::Any;
-
-sub new {
-    my ($class, $loglevel) = @_;
-
-    my $log = Log::Any->get_logger();
-
-    return bless { _log => $log, _level => $loglevel }, $class;
-}
-
-sub debug {
-    my $self = shift;
-
-    Log::Any::Adapter->set(
-        { lexically => \my $set },
-        'AcmeLocal',
-        log_level => $self->{_level},
-    );
-
-    return $self->{_log}->debug(@_);
-}
-
-package Log::Any::Adapter::AcmeLocal;
-
-use strict;
-use warnings;
-
 use Log::Any::Adapter;
-use Log::Any::Adapter::Util ();
-
+use base qw/Log::Any::Adapter::Base/;
 use Time::HiRes qw( gettimeofday );
 
-use base qw/Log::Any::Adapter::Base/;
-
 our $VERSION = '0.12';
 
-my $trace_level;
+my %LOG_LEVELS = (
+                  emergency => 0,
+                  alert     => 1,
+                  critical  => 2,
+                  fatal     => 2,
+                  crit      => 2,
+                  err       => 2,
+                  error     => 3,
+                  warn      => 4,
+                  warning   => 4,
+                  notice    => 5,
+                  inform    => 6,
+                  info      => 6,
+                  debug     => 7,
+                  trace     => 8,
+                 );
 
 sub init {
     my ($self) = @_;
     if ( exists $self->{log_level} ) {
-        $self->{log_level} =
-          Log::Any::Adapter::Util::numeric_level( $self->{log_level} )
+        $self->{log_level} = $LOG_LEVELS{lc($self->{log_level})}
           unless $self->{log_level} =~ /^\d+$/;
     }
     else {
-        $trace_level ||= Log::Any::Adapter::Util::numeric_level('trace');
-        $self->{log_level} = $trace_level;
+        $self->{log_level} = $LOG_LEVELS{trace};
     }
 }
 
-BEGIN {
-    foreach my $method ( Log::Any::Adapter::Util::logging_methods() ) {
-        no strict 'refs';
-        my $method_level = Log::Any::Adapter::Util::numeric_level($method);
-        *{$method} = sub {
-            my ( $self, $text ) = @_;
-            return if $method_level > $self->{log_level};
-
-            my ( $sec, $usec ) = gettimeofday();
-
-            printf STDOUT "%d.%06d %s\n", $sec, $usec, $text;
-        };
-    }
-
-    foreach my $method ( Log::Any::Adapter::Util::detection_methods() ) {
-        no strict 'refs';
-        my $base = substr( $method, 3 );
-        my $method_level = Log::Any::Adapter::Util::numeric_level($base);
-        *{$method} = sub {
-            return !!( $method_level <= $_[0]->{log_level} );
-        };
-    }
+foreach my $method (keys %LOG_LEVELS) {
+    no strict 'refs';
+    my $method_level = $LOG_LEVELS{$method};
+    *{$method} = sub {
+        my ( $self, $text ) = @_;
+        return if $method_level > $self->{log_level};
+        my ( $sec, $usec ) = gettimeofday();
+        printf STDOUT "# %d.%06d %s\n", $sec, $usec, $text;
+    };
+    my $detection_method = 'is_' . $method;
+    *{$detection_method} = sub {
+        return !!( $method_level <= $_[0]->{log_level} );
+    };
 }
 
 1;

--- a/t/02-load_key.t
+++ b/t/02-load_key.t
@@ -68,7 +68,7 @@ eval
       skip "Crypt::OpenSSL::Bignum or Crypt::OpenSSL::RSA not found", 23;
     }
 
-    lives_ok { $acme = Protocol::ACME->new( host => $Protocol::ACME::Test::host ) } 'Create ACME Object';
+    lives_ok { $acme = Protocol::ACME->new( host => $Protocol::ACME::Test::host, debug => 1 ) } 'Create ACME Object';
     lives_ok { $acme->account_key( \$test_objs->{account_key}->{pem} ) } 'Load PEM Buffer';
     ok ( check_key( $acme->{key} ) );
     lives_ok { $acme->account_key( \$test_objs->{account_key}->{der} ) } 'Load DER Buffer';
@@ -105,7 +105,8 @@ eval
     skip "openssl binary not found", 24 unless $Protocol::ACME::Test::openssl;
 
     lives_ok { $acme = Protocol::ACME->new( host => $Protocol::ACME::Test::host,
-                                            openssl => $Protocol::ACME::Test::openssl ) } 'Create ACME Object - OpenSSL';
+                                            openssl => $Protocol::ACME::Test::openssl,
+                                            debug => 1 ) } 'Create ACME Object - OpenSSL';
     lives_ok { $acme->account_key( \$test_objs->{account_key}->{pem} ) } 'Load PEM Buffer - OpenSSL';
     ok ( check_key( $acme->{key} ) );
     lives_ok { $acme->account_key( \$test_objs->{account_key}->{der} ) } 'Load DER Buffer - OpenSSL';

--- a/t/04-load_key_crypt.t
+++ b/t/04-load_key_crypt.t
@@ -36,6 +36,7 @@ eval
   {
     $acme = Protocol::ACME->new( host               => $Protocol::ACME::Test::host,
                                  account_key        => \$Protocol::ACME::Test::account_key_pem,
+                                 loglevel => 'debug',
                                );
   } 'Create ACME Object';
 


### PR DESCRIPTION
Weird enough, the big problem for the dependencies was Log::Any, because
of the old version in debian stable.

However, Log::Any should be used to increase the compatibility, not to
complicate the things.

Also, the logger itself which was used in the main module didn't look
functional (as only ->debug was implemented and was dying on ->warn, for
example), so I took the liberty to refactor the Logger and use it as logger.

All existing tests pass.

However, it's still to be seen if it's actually working as advised (as this
step was a prerequisite to do it).

See https://github.com/sludin/Protocol-ACME/issues/30

PLEASE NOTE: not ready to be merged, PR issued to discuss the change.
